### PR TITLE
Remove container options

### DIFF
--- a/layouts/four-column/layout--four-column.html.twig
+++ b/layouts/four-column/layout--four-column.html.twig
@@ -20,7 +20,8 @@
   set row_classes = [
     'row',
     'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--four-column'
+    'ucb-bootstrap-layout__row--four-column',
+	'g-0'
   ]
 %}
 
@@ -42,31 +43,32 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		<div{{attributes.addClass(row_classes|join(' '))}}>
+		<div class="container g-0">
+			<div{{attributes.addClass(row_classes|join(' '))}}>
+				{% if content.first %}
+					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-md-6 col-12') }}>
+						{{ content.first }}
+					</div>
+				{% endif %}
 
-			{% if content.first %}
-				<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-md-6 col-12') }}>
-					{{ content.first }}
-				</div>
-			{% endif %}
+				{% if content.second %}
+					<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-md-6 col-12') }}>
+						{{ content.second }}
+					</div>
+				{% endif %}
 
-			{% if content.second %}
-				<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-md-6 col-12') }}>
-					{{ content.second }}
-				</div>
-			{% endif %}
+				{% if content.third %}
+					<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-md-6 col-12') }}>
+						{{ content.third }}
+					</div>
+				{% endif %}
 
-			{% if content.third %}
-				<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-md-6 col-12') }}>
-					{{ content.third }}
-				</div>
-			{% endif %}
-
-			{% if content.fourth %}
-				<div {{ region_attributes.fourth.addClass('column', 'col-lg-' ~ column_widths.3, 'column--fourth', 'col-md-6 col-12') }}>
-					{{ content.fourth }}
-				</div>
-			{% endif %}
+				{% if content.fourth %}
+					<div {{ region_attributes.fourth.addClass('column', 'col-lg-' ~ column_widths.3, 'column--fourth', 'col-md-6 col-12') }}>
+						{{ content.fourth }}
+					</div>
+				{% endif %}
+			</div>
 		</div>
 	</div>
 {% endif %}

--- a/layouts/four-column/layout--four-column.html.twig
+++ b/layouts/four-column/layout--four-column.html.twig
@@ -24,10 +24,6 @@
   ]
 %}
 
-{% if settings.container_width == 'edge-to-edge' %}
-	{% set row_classes = row_classes|merge(['g-0']) %}
-{% endif %}
-
 {% if (settings.background_color == 'black') or (settings.background_color == 'dark-gray') %}
 	{% set row_color_settings = "ucb-bootstrap-layout-section-dark" %}
 {% else %}
@@ -46,39 +42,31 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		{% if settings.container_width == 'container' %}
-			<div class="{{ settings.container_width }}">
+		<div{{attributes.addClass(row_classes|join(' '))}}>
+
+			{% if content.first %}
+				<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-md-6 col-12') }}>
+					{{ content.first }}
+				</div>
 			{% endif %}
-			<div{{attributes.addClass(row_classes|join(' '))}}>
 
-				{% if content.first %}
-					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-md-6 col-12') }}>
-						{{ content.first }}
-					</div>
-				{% endif %}
+			{% if content.second %}
+				<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-md-6 col-12') }}>
+					{{ content.second }}
+				</div>
+			{% endif %}
 
-				{% if content.second %}
-					<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-md-6 col-12') }}>
-						{{ content.second }}
-					</div>
-				{% endif %}
+			{% if content.third %}
+				<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-md-6 col-12') }}>
+					{{ content.third }}
+				</div>
+			{% endif %}
 
-				{% if content.third %}
-					<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-md-6 col-12') }}>
-						{{ content.third }}
-					</div>
-				{% endif %}
-
-				{% if content.fourth %}
-					<div {{ region_attributes.fourth.addClass('column', 'col-lg-' ~ column_widths.3, 'column--fourth', 'col-md-6 col-12') }}>
-						{{ content.fourth }}
-					</div>
-				{% endif %}
-
-			</div>
-
-			{% if settings.container_width == 'container' %}
-			</div>
-		{% endif %}
+			{% if content.fourth %}
+				<div {{ region_attributes.fourth.addClass('column', 'col-lg-' ~ column_widths.3, 'column--fourth', 'col-md-6 col-12') }}>
+					{{ content.fourth }}
+				</div>
+			{% endif %}
+		</div>
 	</div>
 {% endif %}

--- a/layouts/one-column/layout--one-column.html.twig
+++ b/layouts/one-column/layout--one-column.html.twig
@@ -16,7 +16,8 @@
   set row_classes = [
     'row',
     'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--one-column'
+    'ucb-bootstrap-layout__row--one-column',
+	'g-0'
   ]
 %}
 

--- a/layouts/one-column/layout--one-column.html.twig
+++ b/layouts/one-column/layout--one-column.html.twig
@@ -20,10 +20,6 @@
   ]
 %}
 
-{% if settings.container_width == 'edge-to-edge' %}
-	{% set row_classes = row_classes|merge(['g-0']) %}
-{% endif %}
-
 {% if (settings.background_color == 'black') or (settings.background_color == 'dark-gray') %}
 	{% set row_color_settings = "ucb-bootstrap-layout-section-dark" %}
 {% else %}
@@ -43,16 +39,10 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		{% if settings.container_width == 'container' %}
-			<div class="{{ settings.container_width }}">
-			{% endif %}
-			<div{{attributes.addClass(row_classes|join(' '))}}>
-				<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>
-					{{ content.first }}
-				</div>
+		<div{{attributes.addClass(row_classes|join(' '))}}>
+			<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>
+				{{ content.first }}
 			</div>
-			{% if settings.container_width == 'container' %}
-			</div>
-		{% endif %}
+		</div>
 	</div>
 {% endif %}

--- a/layouts/three-column/layout--three-column.html.twig
+++ b/layouts/three-column/layout--three-column.html.twig
@@ -24,9 +24,6 @@
   ]
 %}
 
-{% if settings.container_width == 'edge-to-edge' %}
-	{% set row_classes = row_classes|merge(['g-0']) %}
-{% endif %}
 
 {% if (settings.background_color == 'black') or (settings.background_color == 'dark-gray') %}
 	{% set row_color_settings = "ucb-bootstrap-layout-section-dark" %}
@@ -46,32 +43,25 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		{% if settings.container_width == 'container' %}
-			<div class="{{ settings.container_width }}">
+		<div{{attributes.addClass(row_classes|join(' '))}}>
+
+			{% if content.first %}
+				<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
+					{{ content.first }}
+				</div>
 			{% endif %}
-			<div{{attributes.addClass(row_classes|join(' '))}}>
 
-				{% if content.first %}
-					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
-						{{ content.first }}
-					</div>
-				{% endif %}
+			{% if content.second %}
+				<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
+					{{ content.second }}
+				</div>
+			{% endif %}
 
-				{% if content.second %}
-					<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
-						{{ content.second }}
-					</div>
-				{% endif %}
-
-				{% if content.third %}
-					<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-12') }}>
-						{{ content.third }}
-					</div>
-				{% endif %}
-
-			</div>
-			{% if settings.container_width == 'container' %}
-			</div>
-		{% endif %}
+			{% if content.third %}
+				<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-12') }}>
+					{{ content.third }}
+				</div>
+			{% endif %}
+		</div>
 	</div>
 {% endif %}

--- a/layouts/three-column/layout--three-column.html.twig
+++ b/layouts/three-column/layout--three-column.html.twig
@@ -20,7 +20,8 @@
   set row_classes = [
     'row',
     'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--three-column'
+    'ucb-bootstrap-layout__row--three-column',
+	'g-0'
   ]
 %}
 
@@ -43,25 +44,26 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		<div{{attributes.addClass(row_classes|join(' '))}}>
+		<div class="container g-0">
+			<div{{attributes.addClass(row_classes|join(' '))}}>
+				{% if content.first %}
+					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
+						{{ content.first }}
+					</div>
+				{% endif %}
 
-			{% if content.first %}
-				<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
-					{{ content.first }}
-				</div>
-			{% endif %}
+				{% if content.second %}
+					<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
+						{{ content.second }}
+					</div>
+				{% endif %}
 
-			{% if content.second %}
-				<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
-					{{ content.second }}
-				</div>
-			{% endif %}
-
-			{% if content.third %}
-				<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-12') }}>
-					{{ content.third }}
-				</div>
-			{% endif %}
+				{% if content.third %}
+					<div {{ region_attributes.third.addClass('column', 'col-lg-' ~ column_widths.2, 'column--third', 'col-12') }}>
+						{{ content.third }}
+					</div>
+				{% endif %}
+			</div>
 		</div>
 	</div>
 {% endif %}

--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -24,10 +24,6 @@
   ]
 %}
 
-{% if settings.container_width == 'edge-to-edge' %}
-	{% set row_classes = row_classes|merge(['g-0']) %}
-{% endif %}
-
 {% if (settings.background_color == 'black') or (settings.background_color == 'dark-gray') %}
 	{% set row_color_settings = "ucb-bootstrap-layout-section-dark" %}
 {% else %}
@@ -46,25 +42,17 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		{% if settings.container_width == 'container' %}
-			<div class="{{ settings.container_width }}">
+		<div{{attributes.addClass(row_classes|join(' '))}}>
+			{% if content.first %}
+				<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
+					{{ content.first }}
+				</div>
 			{% endif %}
-			<div{{attributes.addClass(row_classes|join(' '))}}>
-
-				{% if content.first %}
-					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
-						{{ content.first }}
-					</div>
-				{% endif %}
-
-				{% if content.second %}
-					<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
-						{{ content.second }}
-					</div>
-				{% endif %}
-			</div>
-			{% if settings.container_width == 'container' %}
-			</div>
-		{% endif %}
+			{% if content.second %}
+				<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
+					{{ content.second }}
+				</div>
+			{% endif %}
+		</div>
 	</div>
 {% endif %}

--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -20,7 +20,8 @@
   set row_classes = [
     'row',
     'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--two-column'
+    'ucb-bootstrap-layout__row--two-column',
+	'g-0'
   ]
 %}
 
@@ -42,17 +43,19 @@
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_color_settings }} {{ row_overlay_settings }}" style="{{ settings.background_image_styles }}">
-		<div{{attributes.addClass(row_classes|join(' '))}}>
-			{% if content.first %}
-				<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
-					{{ content.first }}
-				</div>
-			{% endif %}
-			{% if content.second %}
-				<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
-					{{ content.second }}
-				</div>
-			{% endif %}
+		<div class="container g-0">
+			<div{{attributes.addClass(row_classes|join(' '))}}>
+				{% if content.first %}
+					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
+						{{ content.first }}
+					</div>
+				{% endif %}
+				{% if content.second %}
+					<div {{ region_attributes.second.addClass('column', 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
+						{{ content.second }}
+					</div>
+				{% endif %}
+			</div>
 		</div>
 	</div>
 {% endif %}

--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -57,7 +57,7 @@ abstract class LayoutBase extends LayoutDefault {
   public function defaultConfiguration(): array {
     return [
       'background_color' => UCBLayout::ROW_BACKGROUND_COLOR_NONE,
-      'container_width' => UCBLayout::ROW_CONTAINER_WIDTH_REGULAR,
+      /**'container_width' => UCBLayout::ROW_CONTAINER_WIDTH_REGULAR,**/
       'background_image' == NULL,
       'background_image_styles' == NULL,
       'overlay_color' => UCBLayout::ROW_OVERLAY_COLOR_BLACK,
@@ -76,7 +76,7 @@ abstract class LayoutBase extends LayoutDefault {
     $backgroundColorOptions = $this->getBackgroundColorOptions();
     $overlayColorOptions = $this->getOverlayColorOptions();
     $columnWidths = $this->getColumnWidths();
-    $containerWidths = $this->getContainerWidths();
+    /**$containerWidths = $this->getContainerWidths();**/
     /*
     $paddingTopOptions = $this->getPaddingTopOptions();
     $paddingBottomOptions = $this->getPaddingBottomOptions();
@@ -128,6 +128,7 @@ abstract class LayoutBase extends LayoutDefault {
         '#required' => TRUE,
       ];
 
+      /*
       $form['layout']['container_width'] = [
         '#type' => 'radios',
         '#title' => $this->t('Content Width'),
@@ -135,6 +136,7 @@ abstract class LayoutBase extends LayoutDefault {
         '#default_value' => $this->configuration['container_width'],
         '#required' => TRUE,
       ];
+      */
 
       /*
       $form['layout']['column_padding_top'] = [
@@ -227,7 +229,7 @@ abstract class LayoutBase extends LayoutDefault {
     /*$this->configuration['class'] = $values['extra']['class'];*/
     $this->configuration['background_image'] = $values['background']['background_image'] ?? NULL;
     $this->configuration['column_width'] = $values['layout']['column_width'];
-    $this->configuration['container_width'] = $values['layout']['container_width'];
+    /**$this->configuration['container_width'] = $values['layout']['container_width'];**/
    /*$this->configuration['column_padding_top'] = $values['layout']['column_padding_top'];
     $this->configuration['column_padding_bottom'] = $values['layout']['column_padding_bottom'];*/
     $this->configuration['background_image_styles'] =  $new_styles;
@@ -319,12 +321,13 @@ abstract class LayoutBase extends LayoutDefault {
    *     The container width.
    * 
    **/
-  protected function getContainerWidths(): array {
+  /**protected function getContainerWidths(): array {
     return [
       UCBLayout::ROW_CONTAINER_WIDTH_REGULAR => $this->t('Contained'),
       UCBLayout::ROW_CONTAINER_WIDTH_FLUID => $this->t('Edge-to-edge'),
     ];
   }
+  **/
 
   /**
    * Determine if this layout has background settings.


### PR DESCRIPTION
Removed the ability to choose between contained and edge-to-edge options. All images and background colors are edge to edge. Hero Units now go edge to edge by default as well now.

Related to issue 145 in theme repo
https://github.com/CuBoulder/tiamat-theme/pull/151 