### PR TITLE
'None' Overlay Option

### DIFF
--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -60,7 +60,7 @@ abstract class LayoutBase extends LayoutDefault {
       /**'container_width' => UCBLayout::ROW_CONTAINER_WIDTH_REGULAR,**/
       'background_image' == NULL,
       'background_image_styles' == NULL,
-      'overlay_color' => UCBLayout::ROW_OVERLAY_COLOR_BLACK,
+      'overlay_color' => UCBLayout::ROW_OVERLAY_COLOR_NONE,
       'class' => NULL,
       'column_width' => $this->getDefaultColumnWidth(),
       /*'column_padding_top' => UCBLayout::ROW_TOP_PADDING_NONE,
@@ -201,8 +201,11 @@ abstract class LayoutBase extends LayoutDefault {
     if ($overlay_selection == "black"){
       $overlay_styles = "linear-gradient(rgb(20, 20, 20, 0.5), rgb(20, 20, 20, 0.5))";
     }
-    else {
+    elseif ($overlay_selection == "white"){
       $overlay_styles = "linear-gradient(rgb(200, 200, 200, 0.7), rgb(200, 200, 200, 0.7))";
+    }
+    else {
+      $overlay_styles = "linear-gradient(rgb(255, 255, 255, 0.0), rgb(255, 255, 255, 0.0))";
     }
 
 
@@ -292,6 +295,7 @@ abstract class LayoutBase extends LayoutDefault {
    */
   protected function getOverlayColorOptions(): array {
     return [
+      UCBLayout::ROW_OVERLAY_COLOR_NONE => $this->t('None'),
       UCBLayout::ROW_OVERLAY_COLOR_BLACK => $this->t('Dark'),
       UCBLayout::ROW_OVERLAY_COLOR_WHITE => $this->t('Light'),
     ];

--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -205,7 +205,7 @@ abstract class LayoutBase extends LayoutDefault {
       $overlay_styles = "linear-gradient(rgb(200, 200, 200, 0.7), rgb(200, 200, 200, 0.7))";
     }
     else {
-      $overlay_styles = "linear-gradient(rgb(255, 255, 255, 0.0), rgb(255, 255, 255, 0.0))";
+      $overlay_styles = "none";
     }
 
 

--- a/src/UCBLayout.php
+++ b/src/UCBLayout.php
@@ -59,6 +59,8 @@ final class UCBLayout {
 
   public const ROW_CONTAINER_WIDTH_REGULAR = 'container';
 
+  public const ROW_OVERLAY_COLOR_NONE = 'none';
+
   public const ROW_OVERLAY_COLOR_BLACK = 'black';
   
   public const ROW_OVERLAY_COLOR_WHITE = 'white';


### PR DESCRIPTION
Added 'none' as an overlay color option.
Set 'none' as the default option.

Closes #5 