### PR TITLE
edge-to-edge update

### DIFF
--- a/layouts/edge-to-edge/layout--edge-to-edge.html.twig
+++ b/layouts/edge-to-edge/layout--edge-to-edge.html.twig
@@ -63,7 +63,7 @@ jarallax(document.querySelectorAll('.jarallax'), {speed: 0.2});
 
 {% if content %}
 	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
-		<div class="container ucb-contained-row">
+		<div class="ucb-edge-to-edge">
 			<div{{attributes.addClass(row_classes,frame_classes|join(''))}}>
 				<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>
 					{{ content.first }}

--- a/src/Plugin/Layout/EdgeToEdgeLayout.php
+++ b/src/Plugin/Layout/EdgeToEdgeLayout.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\ucb_bootstrap_layouts\Plugin\Layout;
+
+use Drupal\ucb_bootstrap_layouts\UCBLayout;
+
+/**
+ * Provides a plugin class for a one column layout.
+ */
+final class EdgeToEdgeLayout extends LayoutBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getColumnWidths(): array {
+    return [
+      UCBLayout::ROW_WIDTH_EDGE_TO_EDGE => $this->t('100%'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getDefaultColumnWidth(): string {
+    return UCBLayout::ROW_WIDTH_EDGE_TO_EDGE;
+  }
+
+}

--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -235,63 +235,66 @@ abstract class LayoutBase extends LayoutDefault
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state)
   {
-    $values = $form_state->getValues();
-    $media = $values['background']['background_image'] ?? NULL;
-    $overlay_selection = $values['background']['overlay_color'];
-    $overlay_styles = "";
-    $new_styles = "";
-    $top_padding = $values['spacing']['section_padding_top'];
-    $right_padding = $values['spacing']['section_padding_right'];
-    $bottom_padding = $values['spacing']['section_padding_bottom'];
-    $left_padding = $values['spacing']['section_padding_left'];
 
-    if ($overlay_selection == "black") {
-      $overlay_styles = "linear-gradient(rgb(20, 20, 20, 0.5), rgb(20, 20, 20, 0.5))";
-    } elseif ($overlay_selection == "white") {
-      $overlay_styles = "linear-gradient(rgb(200, 200, 200, 0.7), rgb(200, 200, 200, 0.7))";
-    } else {
-      $overlay_styles = "none";
-    }
+    if ($this->configuration['column_width'] != '13') {
+      $values = $form_state->getValues();
+      $media = $values['background']['background_image'] ?? NULL;
+      $overlay_selection = $values['background']['overlay_color'];
+      $overlay_styles = "";
+      $new_styles = "";
+      $top_padding = $values['spacing']['section_padding_top'];
+      $right_padding = $values['spacing']['section_padding_right'];
+      $bottom_padding = $values['spacing']['section_padding_bottom'];
+      $left_padding = $values['spacing']['section_padding_left'];
+
+      if ($overlay_selection == "black") {
+        $overlay_styles = "linear-gradient(rgb(20, 20, 20, 0.5), rgb(20, 20, 20, 0.5))";
+      } elseif ($overlay_selection == "white") {
+        $overlay_styles = "linear-gradient(rgb(200, 200, 200, 0.7), rgb(200, 200, 200, 0.7))";
+      } else {
+        $overlay_styles = "none";
+      }
 
 
-    if ($media) {
-      $media_entity = Media::load($media);
-      if ($media_entity) {
-        $fid = $media_entity->getSource()->getSourceFieldValue($media_entity);
-        $file = File::load($fid);
-        $url = $file->createFileUrl();
+      if ($media) {
+        $media_entity = Media::load($media);
+        if ($media_entity) {
+          $fid = $media_entity->getSource()->getSourceFieldValue($media_entity);
+          $file = File::load($fid);
+          $url = $file->createFileUrl();
+          $media_image_styles = [
+            'background:  ' . $overlay_styles . ', url(' . $url . ');',
+            'background-position: center;',
+            'background-size: cover;',
+            'background-repeat: no-repeat;',
+            'padding:' . $top_padding . ' ' . $right_padding . ' ' . $bottom_padding . ' ' . $left_padding,
+          ];
+
+          $new_styles = implode(' ', $media_image_styles);
+
+        }
+      } else {
         $media_image_styles = [
-          'background:  ' . $overlay_styles . ', url(' . $url . ');',
-          'background-position: center;',
-          'background-size: cover;',
-          'background-repeat: no-repeat;',
           'padding:' . $top_padding . ' ' . $right_padding . ' ' . $bottom_padding . ' ' . $left_padding,
         ];
 
         $new_styles = implode(' ', $media_image_styles);
-
       }
-    } else {
-      $media_image_styles = [
-        'padding:' . $top_padding . ' ' . $right_padding . ' ' . $bottom_padding . ' ' . $left_padding,
-      ];
 
-      $new_styles = implode(' ', $media_image_styles);
+      $this->configuration['background_color'] = $values['background']['background_color'];
+      /*$this->configuration['class'] = $values['extra']['class'];*/
+      $this->configuration['background_image'] = $values['background']['background_image'] ?? NULL;
+      $this->configuration['column_width'] = $values['layout']['column_width'];
+      $this->configuration['background_image_styles'] = $new_styles;
+      $this->configuration['overlay_color'] = $values['background']['overlay_color'];
+      $this->configuration['background_effect'] = $values['background']['background_effect'];
+      $this->configuration['content_frame_color'] = $values['background']['content_frame_color'];
+      $this->configuration['section_padding_top'] = $values['spacing']['section_padding_top'];
+      $this->configuration['section_padding_right'] = $values['spacing']['section_padding_right'];
+      $this->configuration['section_padding_bottom'] = $values['spacing']['section_padding_bottom'];
+      $this->configuration['section_padding_left'] = $values['spacing']['section_padding_left'];
     }
 
-
-    $this->configuration['background_color'] = $values['background']['background_color'];
-    /*$this->configuration['class'] = $values['extra']['class'];*/
-    $this->configuration['background_image'] = $values['background']['background_image'] ?? NULL;
-    $this->configuration['column_width'] = $values['layout']['column_width'];
-    $this->configuration['background_image_styles'] = $new_styles;
-    $this->configuration['overlay_color'] = $values['background']['overlay_color'];
-    $this->configuration['background_effect'] = $values['background']['background_effect'];
-    $this->configuration['content_frame_color'] = $values['background']['content_frame_color'];
-    $this->configuration['section_padding_top'] = $values['spacing']['section_padding_top'];
-    $this->configuration['section_padding_right'] = $values['spacing']['section_padding_right'];
-    $this->configuration['section_padding_bottom'] = $values['spacing']['section_padding_bottom'];
-    $this->configuration['section_padding_left'] = $values['spacing']['section_padding_left'];
   }
 
   /**

--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\ucb_bootstrap_layouts\Plugin\Layout;
 
@@ -15,12 +15,14 @@ use Drupal\file\Entity\File;
 /**
  * Provides a layout base for custom layouts.
  */
-abstract class LayoutBase extends LayoutDefault {
+abstract class LayoutBase extends LayoutDefault
+{
 
   /**
    * {@inheritdoc}
    */
-  public function build(array $regions): array {
+  public function build(array $regions): array
+  {
     $build = parent::build($regions);
 
     $columnWidth = $this->configuration['column_width'];
@@ -54,11 +56,11 @@ abstract class LayoutBase extends LayoutDefault {
   /**
    * {@inheritdoc}
    */
-  public function defaultConfiguration(): array {
+  public function defaultConfiguration(): array
+  {
     return [
       'background_color' => UCBLayout::ROW_BACKGROUND_COLOR_NONE,
       'content_frame_color' => UCBLayout::ROW_CONTENT_FRAME_COLOR_NONE,
-      'container_width' => UCBLayout::ROW_CONTAINER_WIDTH_REGULAR,
       'background_image' == NULL,
       'background_image_styles' == NULL,
       'overlay_color' => UCBLayout::ROW_OVERLAY_COLOR_NONE,
@@ -75,93 +77,83 @@ abstract class LayoutBase extends LayoutDefault {
   /**
    * {@inheritdoc}
    */
-  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array
+  {
 
     $backgroundColorOptions = $this->getBackgroundColorOptions();
     $contentFrameColorOptions = $this->getContentFrameColorOptions();
     $overlayColorOptions = $this->getOverlayColorOptions();
     $backgroundEffectOptions = $this->getBackgroundEffectOptions();
     $columnWidths = $this->getColumnWidths();
-    $containerWidths = $this->getContainerWidths();
     /*
     $paddingTopOptions = $this->getPaddingTopOptions();
     $paddingBottomOptions = $this->getPaddingBottomOptions();
     */
 
-    $form['background'] = [
-      '#type' => 'details',
-      '#title' => $this->t('Background'),
-      '#open' => FALSE,
-      '#weight' => 30,
-    ];
+    if ($this->configuration['column_width'] != '13') {
 
-    $form['background']['background_color'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Background Color'),
-      '#options' => $backgroundColorOptions,
-      '#default_value' => $this->configuration['background_color'],
-    ];
-
-    $form['background']['background_image'] = [
-      '#type' => 'media_library',
-      '#allowed_bundles' => ['image'],
-      '#title' => $this->t('Background Image'),
-      '#default_value' => $this->configuration['background_image'] ?? NULL,
-      '#description' => $this->t('Upload or select a background image.'),
-    ];
-
-    $form['background']['overlay_color'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Image Overlay Color'),
-      '#options' => $overlayColorOptions,
-      '#default_value' => $this->configuration['overlay_color'],
-      '#description' => $this->t('Only applied if a background image is chosen.'),
-    ];
-
-    $form['background']['background_effect'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Background Effect'),
-      '#options' => $backgroundEffectOptions,
-      '#default_value' => $this->configuration['background_effect'],
-      '#description' => $this->t('Choose an effect for the background image.'),
-    ];
-
-    $form['background']['content_frame_color'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Content Frame Color'),
-      '#options' => $contentFrameColorOptions,
-      '#default_value' => $this->configuration['content_frame_color'],
-      '#description' => $this->t('Choose a color for the inner frame of the content.'),
-    ];
-
-    if (!empty($columnWidths)) {
-      $form['layout'] = [
+      $form['background'] = [
         '#type' => 'details',
-        '#title' => $this->t('Layout'),
-        '#open' => TRUE,
-        '#weight' => 20,
+        '#title' => $this->t('Background'),
+        '#open' => FALSE,
+        '#weight' => 30,
       ];
 
-      $form['layout']['column_width'] = [
+      $form['background']['background_color'] = [
         '#type' => 'radios',
-        '#title' => $this->t('Column Width'),
-        '#options' => $columnWidths,
-        '#default_value' => $this->configuration['column_width'],
-        '#required' => TRUE,
+        '#title' => $this->t('Background Color'),
+        '#options' => $backgroundColorOptions,
+        '#default_value' => $this->configuration['background_color'],
       ];
-    }
 
-    if ($this->configuration['column_width'] == '12'){
-      $form['layout']['container_width'] = [
+      $form['background']['background_image'] = [
+        '#type' => 'media_library',
+        '#allowed_bundles' => ['image'],
+        '#title' => $this->t('Background Image'),
+        '#default_value' => $this->configuration['background_image'] ?? NULL,
+        '#description' => $this->t('Upload or select a background image.'),
+      ];
+
+      $form['background']['overlay_color'] = [
         '#type' => 'radios',
-        '#title' => $this->t('Container Width'),
-        '#options' => $containerWidths,
-        '#default_value' => $this->configuration['container_width'],
-        '#required' => TRUE,
-        '#description' => $this->t('Choose whether hero units, slider, or video reveals display full width.'),
-
+        '#title' => $this->t('Image Overlay Color'),
+        '#options' => $overlayColorOptions,
+        '#default_value' => $this->configuration['overlay_color'],
+        '#description' => $this->t('Only applied if a background image is chosen.'),
       ];
-    }
+
+      $form['background']['background_effect'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Background Effect'),
+        '#options' => $backgroundEffectOptions,
+        '#default_value' => $this->configuration['background_effect'],
+        '#description' => $this->t('Choose an effect for the background image.'),
+      ];
+
+      $form['background']['content_frame_color'] = [
+        '#type' => 'radios',
+        '#title' => $this->t('Content Frame Color'),
+        '#options' => $contentFrameColorOptions,
+        '#default_value' => $this->configuration['content_frame_color'],
+        '#description' => $this->t('Choose a color for the inner frame of the content.'),
+      ];
+
+      if (!empty($columnWidths)) {
+        $form['layout'] = [
+          '#type' => 'details',
+          '#title' => $this->t('Layout'),
+          '#open' => TRUE,
+          '#weight' => 20,
+        ];
+
+        $form['layout']['column_width'] = [
+          '#type' => 'radios',
+          '#title' => $this->t('Column Width'),
+          '#options' => $columnWidths,
+          '#default_value' => $this->configuration['column_width'],
+          '#required' => TRUE,
+        ];
+      }
 
       $form['spacing'] = [
         '#type' => 'details',
@@ -170,7 +162,7 @@ abstract class LayoutBase extends LayoutDefault {
         '#weight' => 40,
       ];
 
-      
+
       $form['spacing']['section_padding_top'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Top Section Padding'),
@@ -215,6 +207,8 @@ abstract class LayoutBase extends LayoutDefault {
         ],
       ];
 
+    }
+
     $form['#attached']['library'][] = 'ucb_bootstrap_layouts/layout_builder';
 
     return $form;
@@ -224,8 +218,7 @@ abstract class LayoutBase extends LayoutDefault {
   {
     $submitted_value = $element['#value'];
     $regex = "/^\d*+(?:px|%)$/";
-    if (!preg_match($regex, $submitted_value))
-    {
+    if (!preg_match($regex, $submitted_value)) {
       $form_state->setError($element, t('<p style="color: red;">Requires a number that ends with px or %</p>'));
     }
   }
@@ -233,13 +226,15 @@ abstract class LayoutBase extends LayoutDefault {
   /**
    * {@inheritdoc}
    */
-  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state)
+  {
   }
 
   /**
    * {@inheritdoc}
    */
-  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state)
+  {
     $values = $form_state->getValues();
     $media = $values['background']['background_image'] ?? NULL;
     $overlay_selection = $values['background']['overlay_color'];
@@ -250,13 +245,11 @@ abstract class LayoutBase extends LayoutDefault {
     $bottom_padding = $values['spacing']['section_padding_bottom'];
     $left_padding = $values['spacing']['section_padding_left'];
 
-    if ($overlay_selection == "black"){
+    if ($overlay_selection == "black") {
       $overlay_styles = "linear-gradient(rgb(20, 20, 20, 0.5), rgb(20, 20, 20, 0.5))";
-    }
-    elseif ($overlay_selection == "white"){
+    } elseif ($overlay_selection == "white") {
       $overlay_styles = "linear-gradient(rgb(200, 200, 200, 0.7), rgb(200, 200, 200, 0.7))";
-    }
-    else {
+    } else {
       $overlay_styles = "none";
     }
 
@@ -278,22 +271,20 @@ abstract class LayoutBase extends LayoutDefault {
         $new_styles = implode(' ', $media_image_styles);
 
       }
-    }
-    else {
+    } else {
       $media_image_styles = [
         'padding:' . $top_padding . ' ' . $right_padding . ' ' . $bottom_padding . ' ' . $left_padding,
       ];
 
       $new_styles = implode(' ', $media_image_styles);
     }
-    
+
 
     $this->configuration['background_color'] = $values['background']['background_color'];
     /*$this->configuration['class'] = $values['extra']['class'];*/
     $this->configuration['background_image'] = $values['background']['background_image'] ?? NULL;
     $this->configuration['column_width'] = $values['layout']['column_width'];
-    $this->configuration['container_width'] = $values['layout']['container_width'];
-    $this->configuration['background_image_styles'] =  $new_styles;
+    $this->configuration['background_image_styles'] = $new_styles;
     $this->configuration['overlay_color'] = $values['background']['overlay_color'];
     $this->configuration['background_effect'] = $values['background']['background_effect'];
     $this->configuration['content_frame_color'] = $values['background']['content_frame_color'];
@@ -339,7 +330,8 @@ abstract class LayoutBase extends LayoutDefault {
    * @return array
    *   The background color options.
    */
-  protected function getBackgroundColorOptions(): array {
+  protected function getBackgroundColorOptions(): array
+  {
     return [
       UCBLayout::ROW_BACKGROUND_COLOR_NONE => $this->t('None'),
       UCBLayout::ROW_BACKGROUND_COLOR_LIGHT_GRAY => $this->t('Light Gray'),
@@ -355,13 +347,14 @@ abstract class LayoutBase extends LayoutDefault {
     ];
   }
 
-   /**
+  /**
    * Get the content frame color options.
    *
    * @return array
    *   The content frame color options.
    */
-  protected function getContentFrameColorOptions(): array {
+  protected function getContentFrameColorOptions(): array
+  {
     return [
       UCBLayout::ROW_CONTENT_FRAME_COLOR_NONE => $this->t('None'),
       UCBLayout::ROW_CONTENT_FRAME_COLOR_LIGHT_GRAY => $this->t('Light Gray'),
@@ -371,13 +364,14 @@ abstract class LayoutBase extends LayoutDefault {
 
 
 
-/**
+  /**
    * Get the background color options.
    *
    * @return array
    *   The background color options.
    */
-  protected function getOverlayColorOptions(): array {
+  protected function getOverlayColorOptions(): array
+  {
     return [
       UCBLayout::ROW_OVERLAY_COLOR_NONE => $this->t('None'),
       UCBLayout::ROW_OVERLAY_COLOR_BLACK => $this->t('Dark'),
@@ -391,7 +385,8 @@ abstract class LayoutBase extends LayoutDefault {
    * @return array
    *   The background effect options.
    */
-  protected function getBackgroundEffectOptions(): array {
+  protected function getBackgroundEffectOptions(): array
+  {
     return [
       UCBLayout::ROW_BACKGROUND_EFFECT_SCROLL => $this->t('Fixed'),
       UCBLayout::ROW_BACKGROUND_EFFECT_FIXED => $this->t('Scroll'),
@@ -417,31 +412,16 @@ abstract class LayoutBase extends LayoutDefault {
 
 
   /**
-   * Get container width. 
-   *  
-   * @return array
-   *     The container width.
-   * 
-   **/
-protected function getContainerWidths(): array {
-    return [
-      UCBLayout::ROW_CONTAINER_WIDTH_REGULAR => $this->t('Contained'),
-      UCBLayout::ROW_CONTAINER_WIDTH_FLUID => $this->t('Edge-to-edge'),
-    ];
-  }
-
-
-  /**
    * Determine if this layout has background settings.
    *
    * @return bool
    *   If this layout has background settings.
    */
-  protected function hasBackgroundSettings(): bool {
+  protected function hasBackgroundSettings(): bool
+  {
     if (!empty($this->configuration['background_color'])) {
       return TRUE;
-    }
-    else {
+    } else {
       return FALSE;
     }
   }

--- a/src/UCBLayout.php
+++ b/src/UCBLayout.php
@@ -11,6 +11,8 @@ final class UCBLayout {
 
   public const ROW_WIDTH_100 = '12';
 
+  public const ROW_WIDTH_EDGE_TO_EDGE = '13';
+
   public const ROW_WIDTH_75 = '9';
 
   public const ROW_WIDTH_50 = '6';
@@ -66,10 +68,6 @@ final class UCBLayout {
   public const ROW_BACKGROUND_COLOR_LIGHT_GREEN = 'light-green';
 
   public const ROW_BACKGROUND_COLOR_BRICK= 'brick';
-
-  public const ROW_CONTAINER_WIDTH_FLUID = 'edge-to-edge';
-
-  public const ROW_CONTAINER_WIDTH_REGULAR = 'contained';
 
   public const ROW_OVERLAY_COLOR_NONE = 'none';
 

--- a/ucb_bootstrap_layouts.layouts.yml
+++ b/ucb_bootstrap_layouts.layouts.yml
@@ -62,3 +62,15 @@ ucb_bootstrap_layouts__four_column:
     fourth:
       label: Fourth
       
+ucb_bootstrap_layouts__edge-to-edge:
+  label: 'Edge-to-Edge'
+  path: layouts/edge-to-edge
+  template: layout--edge-to-edge
+  class: Drupal\ucb_bootstrap_layouts\Plugin\Layout\EdgeToEdgeLayout
+  category: 'Edge-to-Edge'
+  default_region: first
+  icon_map:
+    - [first]
+  regions:
+    first:
+      label: First


### PR DESCRIPTION
Set up `edge-to-edge` as a separate layout rather than a sub-option for `one column`

It is technically a "13 column" row for the sake of UCBLayout and LayoutBase as to differentiate form options between it and the `one column`

Edge-to-edge does not have the normal form options all the other layouts have but instead just receives defaults for said options. These defaults are passed into the template so everything is "filled out" properly.

Icon on column choice is the same as `One Column` because those icons are made automatically through layout builder based on number of rows in the section.

A test of creating a current single column row with edge-to-edge option, and then updating to the newest code would be good to see how this is going to affect our current sandboxes. 
The site does not break but users will be unable to choose `edge-to-edge` as an option anymore in the `one column` sections. If someone edits a previous `edge-to-edge one column` the form will override to the default `100% contained width` thereby switching it away from `edge-to-edge`. This is a manual process and will not automatically switch after this update is rolled out.

Order of section options:
<img width="296" alt="Screenshot 2024-04-11 at 10 26 54 AM" src="https://github.com/CuBoulder/ucb_bootstrap_layouts/assets/94021017/03f5180a-1804-468c-944c-1af438ed9f4e">


Closes #30 
