### PR TITLE
New frame options

### DIFF
--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -360,8 +360,10 @@ abstract class LayoutBase extends LayoutDefault
   {
     return [
       UCBLayout::ROW_CONTENT_FRAME_COLOR_NONE => $this->t('None'),
-      UCBLayout::ROW_CONTENT_FRAME_COLOR_LIGHT_GRAY => $this->t('Light Gray'),
-      UCBLayout::ROW_CONTENT_FRAME_COLOR_DARK_GRAY => $this->t('Dark Gray')
+      UCBLayout::ROW_CONTENT_FRAME_COLOR_LIGHT_GRAY => $this->t('Semitransparent White'),
+      UCBLayout::ROW_CONTENT_FRAME_COLOR_DARK_GRAY => $this->t('Semitransparent Black'),
+      UCBLayout::ROW_CONTENT_FRAME_COLOR_WHITE => $this->t('White'),
+      UCBLayout::ROW_CONTENT_FRAME_COLOR_BlACK => $this->t('Black'),
     ];
   }
 

--- a/src/UCBLayout.php
+++ b/src/UCBLayout.php
@@ -86,4 +86,8 @@ final class UCBLayout {
   public const ROW_CONTENT_FRAME_COLOR_LIGHT_GRAY = 'light-gray';
 
   public const ROW_CONTENT_FRAME_COLOR_DARK_GRAY = 'dark-gray';
+
+  public const ROW_CONTENT_FRAME_COLOR_WHITE = 'white';
+  
+  public const ROW_CONTENT_FRAME_COLOR_BlACK = 'black';
 }


### PR DESCRIPTION
Added solid white and black options to the frame choice. Renamed the select for light and dark gray to be semitransparent white and black. The variable options are still light and dark gray for purposes of migration.

- `theme` => https://github.com/CuBoulder/tiamat-theme/pull/1037
- `bootstrap_layouts` => https://github.com/CuBoulder/ucb_bootstrap_layouts/pull/47

Resolves #34  