### PR TITLE
Class fixes and additions

### DIFF
--- a/css/ucb-bootstrap-layouts.css
+++ b/css/ucb-bootstrap-layouts.css
@@ -2,7 +2,7 @@
   Styles for the layout builder bootstrap layouts
 */
 
-.ucb-boostrap-layout-section .layout-builder-block {
+.ucb-bootstrap-layout-section .layout-builder-block {
   background-color: transparent;
 }
 

--- a/layouts/edge-to-edge/layout--edge-to-edge.html.twig
+++ b/layouts/edge-to-edge/layout--edge-to-edge.html.twig
@@ -63,7 +63,7 @@ jarallax(document.querySelectorAll('.jarallax'), {speed: 0.2});
 {% endif %}
 
 {% if content %}
-	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
+	<div class="ucb-bootstrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
 		<div class="ucb-edge-to-edge">
 			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}}>
 				<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>

--- a/layouts/four-column/layout--four-column.html.twig
+++ b/layouts/four-column/layout--four-column.html.twig
@@ -30,10 +30,17 @@
   set frameColor = 	'content-frame-' ~ settings.content_frame_color
 %}
 
+{% if settings.content_frame_color == 'none' %}
+  {% set frameStyle = 'content-frame-unstyled' %}
+{% else %}
+  {% set frameStyle = 'content-frame-styled' %}
+{% endif %}
+
 {%
   set frame_classes = [
     'ucb-content-frame',
-	frameColor
+	frameColor,
+	frameStyle
   ]
 %}
 
@@ -68,9 +75,9 @@
 {% endif %}
 
 {% if content %}
-	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
+	<div class="ucb-bootstrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
 		<div class="container ucb-contained-row">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}}>
+			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
 				{% if content.first %}
 					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-md-6 col-12') }}>
 						{{ content.first }}

--- a/layouts/one-column/layout--one-column.html.twig
+++ b/layouts/one-column/layout--one-column.html.twig
@@ -26,10 +26,17 @@
   set frameColor = 	'content-frame-' ~ settings.content_frame_color
 %}
 
+{% if settings.content_frame_color == 'none' %}
+  {% set frameStyle = 'content-frame-unstyled' %}
+{% else %}
+  {% set frameStyle = 'content-frame-styled' %}
+{% endif %}
+
 {%
   set frame_classes = [
     'ucb-content-frame',
-	frameColor
+	frameColor,
+	frameStyle
   ]
 %}
 
@@ -62,9 +69,9 @@ jarallax(document.querySelectorAll('.jarallax'), {speed: 0.2});
 {% endif %}
 
 {% if content %}
-	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
+	<div class="ucb-bootstrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
 		<div class="container ucb-contained-row">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}}>
+			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
 				<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>
 					{{ content.first }}
 				</div>

--- a/layouts/three-column/layout--three-column.html.twig
+++ b/layouts/three-column/layout--three-column.html.twig
@@ -30,10 +30,17 @@
   set frameColor = 	'content-frame-' ~ settings.content_frame_color
 %}
 
+{% if settings.content_frame_color == 'none' %}
+  {% set frameStyle = 'content-frame-unstyled' %}
+{% else %}
+  {% set frameStyle = 'content-frame-styled' %}
+{% endif %}
+
 {%
   set frame_classes = [
     'ucb-content-frame',
-	frameColor
+	frameColor,
+	frameStyle
   ]
 %}
 
@@ -68,9 +75,9 @@
 {% endif %}
 
 {% if content %}
-	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
+	<div class="ucb-bootstrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
 		<div class="container ucb-contained-row">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}}>
+			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
 				{% if content.first %}
 					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
 						{{ content.first }}

--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -30,10 +30,17 @@
   set frameColor = 	'content-frame-' ~ settings.content_frame_color
 %}
 
+{% if settings.content_frame_color == 'none' %}
+  {% set frameStyle = 'content-frame-unstyled' %}
+{% else %}
+  {% set frameStyle = 'content-frame-styled' %}
+{% endif %}
+
 {%
   set frame_classes = [
     'ucb-content-frame',
-	frameColor
+	frameColor,
+	frameStyle
   ]
 %}
 
@@ -68,9 +75,9 @@
 {% endif %}
 
 {% if content %}
-	<div class="ucb-boostrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
+	<div class="ucb-bootstrap-layout-section ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
 		<div class="container ucb-contained-row">
-			<div {{attributes.addClass(row_classes, frame_classes|join(' '))}}>
+			<div {{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
 				{% if (content.first) and (content.first|render|striptags('<img><iframe>')|trim != "")%}
 					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-12', 'flex-grow-1') }}>
 						{{ content.first }}

--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -243,9 +243,9 @@ abstract class LayoutBase extends LayoutDefault
       $overlay_styles = "";
       $new_styles = "";
       $top_padding = $values['spacing']['section_padding_top'];
-      $right_padding = $values['spacing']['section_padding_right'];
+      $right_padding = 0;
       $bottom_padding = $values['spacing']['section_padding_bottom'];
-      $left_padding = $values['spacing']['section_padding_left'];
+      $left_padding = 0;
 
       if ($overlay_selection == "black") {
         $overlay_styles = "linear-gradient(rgb(20, 20, 20, 0.5), rgb(20, 20, 20, 0.5))";


### PR DESCRIPTION
Fixed a name error from `boostrap` -> `bootstrap`
Added new unstyled/styled class names for frames
Moved the left and right padding options on spacing to be on the frame so that alignment works the way Kevin/Wendy have requested.

- `theme` => https://github.com/CuBoulder/tiamat-theme/pull/1055
- `bootstrap_layouts` => https://github.com/CuBoulder/ucb_bootstrap_layouts/pull/48