### PR TITLE
Update LayoutBase.php

### DIFF
--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -8,6 +8,7 @@ use Drupal\ucb_bootstrap_layouts\UCBLayout;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Layout\LayoutDefault;
 use Drupal\media\Entity\Media;
+use Drupal\image\Entity\ImageStyle;
 use Drupal\file\Entity\File;
 
 
@@ -379,7 +380,8 @@ abstract class LayoutBase extends LayoutDefault
         if ($media_entity) {
           $fid = $media_entity->getSource()->getSourceFieldValue($media_entity);
           $file = \Drupal::entityTypeManager()->getStorage('file')->load($fid);
-          $url = $file->createFileUrl();
+          $path = $file->getFileUri();
+          $url = ImageStyle::load('section_background')->buildUrl($path);
 
 
           $crop = \Drupal::service('focal_point.manager')->getCropEntity($file, 'focal_point');


### PR DESCRIPTION
Update section background to use specific style (section_background)
New image style scales width to 1920, but does not crop the height at all.

Because the section background focal point information is % relative this change does not affect or break the previous work done to apply focal positioning of the image.

Note:
If you have a section background already made for a section you will need to first clear caches, then save your section's configuration again to populate the new image style URL. 

Sister PR: https://github.com/CuBoulder/tiamat-custom-entities/pull/173