### PR TITLE
Update layout--two-column.html.twig

### DIFF
--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -127,7 +127,7 @@
 						{{ content.first }}
 					</div>
 				{% endif %}
-				{% if (content.second) and (content.second|render|striptags('<img><iframe>')|trim != "") %}
+				{% if (content.second) and (content.second|render|striptags('<img><iframe><slate-form>')|trim != "") %}
 					<div {{ region_attributes.second.addClass('column', columnHeight, 'col-lg-' ~ column_widths.1, 'column--second', 'col-12', 'flex-grow-1') }}>
 						{{ content.second }}
 					</div>


### PR DESCRIPTION
Add `<slate-form>` to the striptags so that forms in the second column aren't removed in the check for content.

Test by adding a slate form into the second column of a section. The section should have no other content including a title for the slate form block. The slate form should appear as expected.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1363