### PR TITLE
Column Refactor + Jumpmenu update

### DIFF
--- a/layouts/edge-to-edge/layout--edge-to-edge.html.twig
+++ b/layouts/edge-to-edge/layout--edge-to-edge.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a one-column layout.
+ * Default theme implementation to display an edge-to-edge layout.
  *
  * Available variables:
  * - content: The content for this layout.
@@ -15,63 +15,51 @@
 {{ attach_library('ucb_bootstrap_layouts/ucb-bootstrap-layouts') }}
 
 {% set sectionID = settings.sectionID %}
+{% set row_classes = ['row', 'ucb-bootstrap-layout__row', 'ucb-bootstrap-layout__row--one-column', 'g-0'] %}
+{% set frameColor = 'content-frame-' ~ settings.content_frame_color %}
+{% set frameStyle = settings.content_frame_color == 'none' ? 'content-frame-unstyled' : 'content-frame-styled' %}
+{% set frame_classes = ['ucb-content-frame', frameColor, frameStyle] %}
+{% set regions = ['first'] %}
 
-{%
-  set row_classes = [
-    'row',
-    'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--one-column',
-		'g-0'
-  ]
-%}
+<style>
+  .ucb-bootstrap-layout-section.section-{{sectionID}}{
+    padding-top: {{settings.section_mobile_padding_top}}
+    ;
+    padding-bottom: {{settings.section_mobile_padding_bottom}}
+    ;
+  }
 
-{%
-  set frameColor = 	'content-frame-' ~ settings.content_frame_color
-%}
+  @media(min-width: 768px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_tablet_padding_top}}
+      ;
+      padding-bottom: {{settings.section_tablet_padding_bottom}}
+      ;
+    }
+  }
 
-{%
-  set frame_classes = [
-    'ucb-content-frame',
-	frameColor
-  ]
-%}
-
-{% if settings.background_image_styles %}
-	{% if settings.overlay_color == 'black' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-dark" %}
-	{% elseif settings.overlay_color == 'white' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-light" %}
-	{% else %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-none" %}
-	{% endif %}
-{% else %}
-	{% set row_overlay_settings = "" %}
-{% endif %}
-
-{% if settings.background_effect == "fixed" %}
-	{% set row_background_effect = "fixed-background" %}
-{% elseif settings.background_effect == "parallax" %}
-	{% set row_background_effect = "jarallax" %}
-{% else %}
-	{% set row_background_effect = "scrolling-background" %}
-{% endif %}
-
-{% if settings.background_effect == "parallax" %}
-	<script>
-		window.onload = function () {
-jarallax(document.querySelectorAll('.jarallax'), {speed: 0.2});
-};
-	</script>
-{% endif %}
+  @media(min-width: 992px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_padding_top}}
+      ;
+      padding-bottom: {{settings.section_padding_bottom}}
+      ;
+    }
+  }
+</style>
 
 {% if content %}
-	<div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
-		<div class="ucb-edge-to-edge">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}}>
-				<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>
-					{{ content.first }}
-				</div>
-			</div>
-		</div>
-	</div>
+  <div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }}">
+    <div class="ucb-edge-to-edge">
+      <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
+        {% for region in regions %}
+          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form>')|trim != '' %}
+            <div {{ region_attributes[region].addClass('column', 'column--' ~ region, 'col-12', 'main-column') }}>
+              {{ content[region] }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endif %}

--- a/layouts/four-column/layout--four-column.html.twig
+++ b/layouts/four-column/layout--four-column.html.twig
@@ -12,140 +12,79 @@
  */
 #}
 
-{# Get the column widths #}
-
 {{ attach_library('ucb_bootstrap_layouts/ucb-bootstrap-layouts') }}
 
 {% set sectionID = settings.sectionID %}
-
 {% set column_widths = settings.column_width|split('-') %}
-
-{%
-  set row_classes = [
-    'row',
-    'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--four-column'
-  ]
-%}
-
-{%
-  set frameColor = 	'content-frame-' ~ settings.content_frame_color
-%}
-
-{% if settings.content_frame_color == 'none' %}
-  {% set frameStyle = 'content-frame-unstyled' %}
-{% else %}
-  {% set frameStyle = 'content-frame-styled' %}
-{% endif %}
-
-{%
-  set frame_classes = [
-    'ucb-content-frame',
-	frameColor,
-	frameStyle
-  ]
-%}
-
-{% if settings.column_equal_height == '1' %}
-  {% set columnHeight = 'd-flex flex-wrap' %}
-{% else %}
-  {% set columnHeight = '' %}
-{% endif %}
-
-{% if settings.background_image_styles %}
-	{% if settings.overlay_color == 'black' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-dark" %}
-	{% elseif settings.overlay_color == 'white' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-light" %}
-	{% else %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-none" %}
-	{% endif %}
-{% else %}
-	{% set row_overlay_settings = "" %}
-{% endif %}
-
-{% if settings.background_effect == "fixed" %}
-	{% set row_background_effect = "fixed-background" %}
-{% elseif settings.background_effect == "parallax" %}
-	{% set row_background_effect = "jarallax" %}
-{% else %}
-	{% set row_background_effect = "scrolling-background" %}
-{% endif %}
-
-{% if settings.background_effect == "parallax" %}
-	<script>
-		window.onload = function() {
-			jarallax(document.querySelectorAll('.jarallax'), {
-  				speed: 0.2,
-			});
-		};
-	</script>
-{% endif %}
+{% set row_classes = ['row', 'ucb-bootstrap-layout__row', 'ucb-bootstrap-layout__row--four-column'] %}
+{% set frameColor = 'content-frame-' ~ settings.content_frame_color %}
+{% set frameStyle = settings.content_frame_color == 'none' ? 'content-frame-unstyled' : 'content-frame-styled' %}
+{% set frame_classes = ['ucb-content-frame', frameColor, frameStyle] %}
+{% set columnHeight = settings.column_equal_height == '1' ? 'd-flex flex-wrap' : '' %}
+{% set regions = ['first', 'second', 'third', 'fourth'] %}
 
 <style>
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_mobile_padding_top }};
-		padding-bottom: {{settings.section_mobile_padding_bottom }};
-	}
+  .ucb-bootstrap-layout-section.section-{{sectionID}}{
+    padding-top: {{settings.section_mobile_padding_top}}
+    ;
+    padding-bottom: {{settings.section_mobile_padding_bottom}}
+    ;
+  }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_mobile_padding_left }};
-		padding-right: {{settings.section_mobile_padding_right }};
-	}
+  .section-{{sectionID}}.ucb-content-frame {
+    padding-left: {{settings.section_mobile_padding_left}}
+    ;
+    padding-right: {{settings.section_mobile_padding_right}}
+    ;
+  }
 
-@media (min-width: 768px) {
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_tablet_padding_top }};
-		padding-bottom: {{settings.section_tablet_padding_bottom }};
-	}
+  @media(min-width: 768px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_tablet_padding_top}}
+      ;
+      padding-bottom: {{settings.section_tablet_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_tablet_padding_left }};
-		padding-right: {{settings.section_tablet_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_tablet_padding_left}}
+      ;
+      padding-right: {{settings.section_tablet_padding_right}}
+      ;
+    }
+  }
 
-@media (min-width: 992px) {
-	.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_padding_top }};
-		padding-bottom: {{settings.section_padding_bottom }};
-	}
+  @media(min-width: 992px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_padding_top}}
+      ;
+      padding-bottom: {{settings.section_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_padding_left }};
-		padding-right: {{settings.section_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_padding_left}}
+      ;
+      padding-right: {{settings.section_padding_right}}
+      ;
+    }
+  }
 </style>
 
 {% if content %}
-	<div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
-		<div class="container ucb-contained-row">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
-				{% if content.first %}
-					<div {{ region_attributes.first.addClass('column', 'col-lg-' ~ column_widths.0, 'column--first', 'col-md-6 col-12') }}>
-						{{ content.first }}
-					</div>
-				{% endif %}
-
-				{% if content.second %}
-					<div {{ region_attributes.second.addClass('column', columnHeight, 'col-lg-' ~ column_widths.1, 'column--second', 'col-md-6 col-12') }}>
-						{{ content.second }}
-					</div>
-				{% endif %}
-
-				{% if content.third %}
-					<div {{ region_attributes.third.addClass('column', columnHeight, 'col-lg-' ~ column_widths.2, 'column--third', 'col-md-6 col-12') }}>
-						{{ content.third }}
-					</div>
-				{% endif %}
-
-				{% if content.fourth %}
-					<div {{ region_attributes.fourth.addClass('column', columnHeight, 'col-lg-' ~ column_widths.3, 'column--fourth', 'col-md-6 col-12') }}>
-						{{ content.fourth }}
-					</div>
-				{% endif %}
-			</div>
-		</div>
-	</div>
+  <div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }}">
+    <div class="container ucb-contained-row">
+      <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
+        {% for i in 0..(regions|length - 1) %}
+          {% set region = regions[i] %}
+          {% set width = column_widths[i] %}
+          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form>')|trim != '' %}
+            <div {{ region_attributes[region].addClass('column', 'col-lg-' ~ width, 'column--' ~ region, 'col-12', columnHeight, 'main-column') }}>
+              {{ content[region] }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endif %}

--- a/layouts/one-column/layout--one-column.html.twig
+++ b/layouts/one-column/layout--one-column.html.twig
@@ -15,107 +15,94 @@
 {{ attach_library('ucb_bootstrap_layouts/ucb-bootstrap-layouts') }}
 
 {% set sectionID = settings.sectionID %}
-
-{%
-  set row_classes = [
-    'row',
-    'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--one-column'
-  ]
-%}
-
-{%
-  set frameColor = 	'content-frame-' ~ settings.content_frame_color
-%}
-
-{% if settings.content_frame_color == 'none' %}
-  {% set frameStyle = 'content-frame-unstyled' %}
-{% else %}
-  {% set frameStyle = 'content-frame-styled' %}
-{% endif %}
-
-{%
-  set frame_classes = [
-    'ucb-content-frame',
-	frameColor,
-	frameStyle
-  ]
-%}
+{% set row_classes = ['row', 'ucb-bootstrap-layout__row', 'ucb-bootstrap-layout__row--one-column'] %}
+{% set frameColor = 'content-frame-' ~ settings.content_frame_color %}
+{% set frame_classes = ['ucb-content-frame', frameColor] %}
 
 {% if settings.background_image_styles %}
-	{% if settings.overlay_color == 'black' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-dark" %}
-	{% elseif settings.overlay_color == 'white' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-light" %}
-	{% else %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-none" %}
-	{% endif %}
+  {% set row_overlay_settings = settings.overlay_color == 'black' 
+    ? 'ucb-bootstrap-layout-section-overlay-dark' 
+    : settings.overlay_color == 'white' 
+    ? 'ucb-bootstrap-layout-section-overlay-light' 
+    : 'ucb-bootstrap-layout-section-overlay-none' %}
 {% else %}
-	{% set row_overlay_settings = "" %}
+  {% set row_overlay_settings = '' %}
 {% endif %}
 
-{% if settings.background_effect == "fixed" %}
-	{% set row_background_effect = "fixed-background" %}
-{% elseif settings.background_effect == "parallax" %}
-	{% set row_background_effect = "jarallax" %}
-{% else %}
-	{% set row_background_effect = "scrolling-background" %}
-{% endif %}
+{% set row_background_effect = settings.background_effect == 'fixed' 
+  ? 'fixed-background' 
+  : settings.background_effect == 'parallax' 
+  ? 'jarallax' 
+  : 'scrolling-background' %}
 
-{% if settings.background_effect == "parallax" %}
-	<script>
-		window.onload = function () {
-jarallax(document.querySelectorAll('.jarallax'), {speed: 0.2});
-};
-	</script>
+{% if settings.background_effect == 'parallax' %}
+  <script>
+    window.onload = function () {
+      jarallax(document.querySelectorAll('.jarallax'), {speed: 0.2});
+    };
+  </script>
 {% endif %}
 
 <style>
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_mobile_padding_top }};
-		padding-bottom: {{settings.section_mobile_padding_bottom }};
-	}
+  .ucb-bootstrap-layout-section.section-{{sectionID}}{
+    padding-top: {{settings.section_mobile_padding_top}}
+    ;
+    padding-bottom: {{settings.section_mobile_padding_bottom}}
+    ;
+  }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_mobile_padding_left }};
-		padding-right: {{settings.section_mobile_padding_right }};
-	}
+  .section-{{sectionID}}.ucb-content-frame {
+    padding-left: {{settings.section_mobile_padding_left}}
+    ;
+    padding-right: {{settings.section_mobile_padding_right}}
+    ;
+  }
 
-@media (min-width: 768px) {
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_tablet_padding_top }};
-		padding-bottom: {{settings.section_tablet_padding_bottom }};
-	}
+  @media(min-width: 768px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_tablet_padding_top}}
+      ;
+      padding-bottom: {{settings.section_tablet_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_tablet_padding_left }};
-		padding-right: {{settings.section_tablet_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_tablet_padding_left}}
+      ;
+      padding-right: {{settings.section_tablet_padding_right}}
+      ;
+    }
+  }
 
-@media (min-width: 992px) {
-	.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_padding_top }};
-		padding-bottom: {{settings.section_padding_bottom }};
-	}
+  @media(min-width: 992px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_padding_top}}
+      ;
+      padding-bottom: {{settings.section_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_padding_left }};
-		padding-right: {{settings.section_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_padding_left}}
+      ;
+      padding-right: {{settings.section_padding_right}}
+      ;
+    }
+  }
 </style>
 
 {% if content %}
-	<div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
-		<div class="container ucb-contained-row">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}}>
-				<div {{ region_attributes.first.addClass('column', 'column--first', 'col-12') }}>
-					{{ content.first }}
-				</div>
-			</div>
-		</div>
-	</div>
+  <div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
+    <div class="container ucb-contained-row">
+      <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
+        {% for region in ['first'] %}
+          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form>')|trim != '' %}
+            <div {{ region_attributes[region].addClass('column', 'column--' ~ region, 'col-12', 'main-column') }}>
+              {{ content[region] }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endif %}
-
-

--- a/layouts/three-column/layout--three-column.html.twig
+++ b/layouts/three-column/layout--three-column.html.twig
@@ -12,134 +12,81 @@
  */
 #}
 
-{# Get the column widths #}
-
 {{ attach_library('ucb_bootstrap_layouts/ucb-bootstrap-layouts') }}
 
 {% set sectionID = settings.sectionID %}
-
 {% set column_widths = settings.column_width|split('-') %}
-
-{%
-  set row_classes = [
-    'row',
-    'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--three-column'
-  ]
-%}
-
-{%
-  set frameColor = 	'content-frame-' ~ settings.content_frame_color
-%}
-
-{% if settings.content_frame_color == 'none' %}
-  {% set frameStyle = 'content-frame-unstyled' %}
-{% else %}
-  {% set frameStyle = 'content-frame-styled' %}
-{% endif %}
-
-{%
-  set frame_classes = [
-    'ucb-content-frame',
-	frameColor,
-	frameStyle
-  ]
-%}
-
-{% if settings.column_equal_height == '1' %}
-  {% set columnHeight = 'd-flex flex-wrap' %}
-{% else %}
-  {% set columnHeight = '' %}
-{% endif %}
-
-{% if settings.background_image_styles %}
-	{% if settings.overlay_color == 'black' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-dark" %}
-	{% elseif settings.overlay_color == 'white' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-light" %}
-	{% else %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-none" %}
-	{% endif %}
-{% else %}
-	{% set row_overlay_settings = "" %}
-{% endif %}
-
-{% if settings.background_effect == "fixed" %}
-	{% set row_background_effect = "fixed-background" %}
-{% elseif settings.background_effect == "parallax" %}
-	{% set row_background_effect = "jarallax" %}
-{% else %}
-	{% set row_background_effect = "scrolling-background" %}
-{% endif %}
-
-{% if settings.background_effect == "parallax" %}
-	<script>
-		window.onload = function() {
-			jarallax(document.querySelectorAll('.jarallax'), {
-  				speed: 0.2,
-			});
-		};
-	</script>
-{% endif %}
+{% set row_classes = ['row', 'ucb-bootstrap-layout__row', 'ucb-bootstrap-layout__row--three-column'] %}
+{% set frameStyle = settings.content_frame_color == 'none' ? 'content-frame-unstyled' : 'content-frame-styled' %}
+{% set frame_classes = ['ucb-content-frame', frameColor, frameStyle] %}
+{% set columnHeight = settings.column_equal_height == '1' ? 'd-flex flex-wrap' : '' %}
+{% set regions = ['first', 'second', 'third'] %}
+{% set max_width = column_widths|sort|last %}
+{% set all_equal = column_widths|length == column_widths|filter(width => width == column_widths[0])|length %}
 
 <style>
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_mobile_padding_top }};
-		padding-bottom: {{settings.section_mobile_padding_bottom }};
-	}
+  .ucb-bootstrap-layout-section.section-{{sectionID}}{
+    padding-top: {{settings.section_mobile_padding_top}}
+    ;
+    padding-bottom: {{settings.section_mobile_padding_bottom}}
+    ;
+  }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_mobile_padding_left }};
-		padding-right: {{settings.section_mobile_padding_right }};
-	}
+  .section-{{sectionID}}.ucb-content-frame {
+    padding-left: {{settings.section_mobile_padding_left}}
+    ;
+    padding-right: {{settings.section_mobile_padding_right}}
+    ;
+  }
 
-@media (min-width: 768px) {
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_tablet_padding_top }};
-		padding-bottom: {{settings.section_tablet_padding_bottom }};
-	}
+  @media(min-width: 768px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_tablet_padding_top}}
+      ;
+      padding-bottom: {{settings.section_tablet_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_tablet_padding_left }};
-		padding-right: {{settings.section_tablet_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_tablet_padding_left}}
+      ;
+      padding-right: {{settings.section_tablet_padding_right}}
+      ;
+    }
+  }
 
-@media (min-width: 992px) {
-	.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_padding_top }};
-		padding-bottom: {{settings.section_padding_bottom }};
-	}
+  @media(min-width: 992px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_padding_top}}
+      ;
+      padding-bottom: {{settings.section_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_padding_left }};
-		padding-right: {{settings.section_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_padding_left}}
+      ;
+      padding-right: {{settings.section_padding_right}}
+      ;
+    }
+  }
 </style>
 
 {% if content %}
-	<div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
-		<div class="container ucb-contained-row">
-			<div{{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
-				{% if content.first %}
-					<div {{ region_attributes.first.addClass('column', columnHeight, 'col-lg-' ~ column_widths.0, 'column--first', 'col-12') }}>
-						{{ content.first }}
-					</div>
-				{% endif %}
-
-				{% if content.second %}
-					<div {{ region_attributes.second.addClass('column', columnHeight, 'col-lg-' ~ column_widths.1, 'column--second', 'col-12') }}>
-						{{ content.second }}
-					</div>
-				{% endif %}
-
-				{% if content.third %}
-					<div {{ region_attributes.third.addClass('column', columnHeight, 'col-lg-' ~ column_widths.2, 'column--third', 'col-12') }}>
-						{{ content.third }}
-					</div>
-				{% endif %}
-			</div>
-		</div>
-	</div>
+  <div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }}">
+    <div class="container ucb-contained-row">
+      <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
+        {% for i in 0..(regions|length - 1) %}
+          {% set region = regions[i] %}
+          {% set width = column_widths[i] %}
+          {% set column_class = all_equal or width == max_width ? 'main-column' : 'auxiliary-column' %}
+          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form>')|trim != '' %}
+            <div {{ region_attributes[region].addClass('column', column_class, columnHeight, 'col-lg-' ~ width, 'column--' ~ region, 'col-12') }}>
+              {{ content[region] }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endif %}

--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -12,127 +12,82 @@
  */
 #}
 
-{# Get the column widths #}
-
 {{ attach_library('ucb_bootstrap_layouts/ucb-bootstrap-layouts') }}
 
 {% set sectionID = settings.sectionID %}
-
 {% set column_widths = settings.column_width|split('-') %}
-
-{%
-  set row_classes = [
-    'row',
-    'ucb-bootstrap-layout__row',
-    'ucb-bootstrap-layout__row--two-column'
-  ]
-%}
-
-{%
-  set frameColor = 	'content-frame-' ~ settings.content_frame_color
-%}
-
-{% if settings.content_frame_color == 'none' %}
-  {% set frameStyle = 'content-frame-unstyled' %}
-{% else %}
-  {% set frameStyle = 'content-frame-styled' %}
-{% endif %}
-
-{% if settings.column_equal_height == '1' %}
-  {% set columnHeight = 'd-flex flex-wrap' %}
-{% else %}
-  {% set columnHeight = '' %}
-{% endif %}
-
-{%
-  set frame_classes = [
-    'ucb-content-frame',
-	frameColor,
-	frameStyle
-  ]
-%}
-
-{% if settings.background_image_styles %}
-	{% if settings.overlay_color == 'black' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-dark" %}
-	{% elseif settings.overlay_color == 'white' %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-light" %}
-	{% else %}
-		{% set row_overlay_settings = "ucb-bootstrap-layout-section-overlay-none" %}
-	{% endif %}
-{% else %}
-	{% set row_overlay_settings = "" %}
-{% endif %}
-
-{% if settings.background_effect == "fixed" %}
-	{% set row_background_effect = "fixed-background" %}
-{% elseif settings.background_effect == "parallax" %}
-	{% set row_background_effect = "jarallax" %}
-{% else %}
-	{% set row_background_effect = "scrolling-background" %}
-{% endif %}
-
-{% if settings.background_effect == "parallax" %}
-	<script>
-		window.onload = function() {
-			jarallax(document.querySelectorAll('.jarallax'), {
-  				speed: 0.2,
-			});
-		};
-	</script>
-{% endif %}
+{% set row_classes = ['row', 'ucb-bootstrap-layout__row', 'ucb-bootstrap-layout__row--two-column'] %}
+{% set frameColor = 'content-frame-' ~ settings.content_frame_color %}
+{% set frameStyle = settings.content_frame_color == 'none' ? 'content-frame-unstyled' : 'content-frame-styled' %}
+{% set frame_classes = ['ucb-content-frame', frameColor, frameStyle] %}
+{% set columnHeight = settings.column_equal_height == '1' ? 'd-flex flex-wrap' : '' %}
+{% set regions = ['first', 'second'] %}
+{% set max_width = column_widths|sort|last %}
+{% set all_equal = column_widths|length == column_widths|filter(width => width == column_widths[0])|length %}
 
 <style>
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_mobile_padding_top }};
-		padding-bottom: {{settings.section_mobile_padding_bottom }};
-	}
+  .ucb-bootstrap-layout-section.section-{{sectionID}}{
+    padding-top: {{settings.section_mobile_padding_top}}
+    ;
+    padding-bottom: {{settings.section_mobile_padding_bottom}}
+    ;
+  }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_mobile_padding_left }};
-		padding-right: {{settings.section_mobile_padding_right }};
-	}
+  .section-{{sectionID}}.ucb-content-frame {
+    padding-left: {{settings.section_mobile_padding_left}}
+    ;
+    padding-right: {{settings.section_mobile_padding_right}}
+    ;
+  }
 
-@media (min-width: 768px) {
-		.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_tablet_padding_top }};
-		padding-bottom: {{settings.section_tablet_padding_bottom }};
-	}
+  @media(min-width: 768px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_tablet_padding_top}}
+      ;
+      padding-bottom: {{settings.section_tablet_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_tablet_padding_left }};
-		padding-right: {{settings.section_tablet_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_tablet_padding_left}}
+      ;
+      padding-right: {{settings.section_tablet_padding_right}}
+      ;
+    }
+  }
 
-@media (min-width: 992px) {
-	.ucb-bootstrap-layout-section.section-{{ sectionID }} {
-		padding-top: {{ settings.section_padding_top }};
-		padding-bottom: {{settings.section_padding_bottom }};
-	}
+  @media(min-width: 992px) {
+    .ucb-bootstrap-layout-section.section-{{sectionID}}{
+      padding-top: {{settings.section_padding_top}}
+      ;
+      padding-bottom: {{settings.section_padding_bottom}}
+      ;
+    }
 
-	.section-{{ sectionID }} .ucb-content-frame {
-		padding-left: {{ settings.section_padding_left }};
-		padding-right: {{settings.section_padding_right }};
-	}
-}
+    .section-{{sectionID}}.ucb-content-frame {
+      padding-left: {{settings.section_padding_left}}
+      ;
+      padding-right: {{settings.section_padding_right}}
+      ;
+    }
+  }
 </style>
 
 {% if content %}
-	<div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }} {{ row_overlay_settings }} {{ row_background_effect }}" style="{{ settings.background_image_styles }}">
-		<div class="container ucb-contained-row">
-			<div {{attributes.addClass(row_classes, frame_classes|join(' '))}} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
-				{% if (content.first) and (content.first|render|striptags('<img><iframe><slate-form>')|trim != "")%}
-					<div {{ region_attributes.first.addClass('column', columnHeight, 'col-lg-' ~ column_widths.0, 'column--first', 'col-12', 'flex-grow-1') }}>
-						{{ content.first }}
-					</div>
-				{% endif %}
-				{% if (content.second) and (content.second|render|striptags('<img><iframe><slate-form>')|trim != "") %}
-					<div {{ region_attributes.second.addClass('column', columnHeight, 'col-lg-' ~ column_widths.1, 'column--second', 'col-12', 'flex-grow-1') }}>
-						{{ content.second }}
-					</div>
-				{% endif %}
-			</div>
-		</div>
-	</div>
+  <div class="ucb-bootstrap-layout-section section-{{ sectionID }} ucb-bootstrap-layout__background-color--{{ settings.background_color }}">
+    <div class="container ucb-contained-row">
+      <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
+        {% for i in 0..(regions|length - 1) %}
+          {% set region = regions[i] %}
+          {% set width = column_widths[i] %}
+          {% set column_class = all_equal or width == max_width ? 'main-column' : 'auxiliary-column' %}
+          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form>')|trim != '' %}
+            <div {{ region_attributes[region].addClass('column', column_class, columnHeight, 'col-lg-' ~ width, 'column--' ~ region, 'col-12') }}>
+              {{ content[region] }}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
 {% endif %}


### PR DESCRIPTION
Big refactors to how columns are built to be more dynamic rather than prewritten divs per column. This decision was made to cleanup the code and to add in information for column eminence. Main and auxiliary columns need to be labeled as such for jump navs to render properly.

The column eminence mainly affects the two and three column layouts as they can have varying sizes based on user choice. Equal width columns (6-6 and 4-4-4) are treated all as "main"

When testing please test all the layout options for columns in the layout builder.
I don't think I missed any of the layout options in my refactor but double checks would be helpful.

Sister PR:  https://github.com/CuBoulder/ucb_ckeditor_plugins/pull/100

Resolves #63 