### PR TITLE
Update layout--two-column.html.twig

### DIFF
--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -82,7 +82,7 @@
           {% set width = column_widths[i] %}
           {% set column_class = all_equal or width == max_width ? 'main-column' : 'auxiliary-column' %}
           {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form>')|trim != '' %}
-            <div {{ region_attributes[region].addClass('column', column_class, columnHeight, 'col-lg-' ~ width, 'column--' ~ region, 'col-12') }}>
+            <div {{ region_attributes[region].addClass('column', column_class, columnHeight, 'col-lg-' ~ width, 'column--' ~ region, 'col-12 flex-grow-1') }}>
               {{ content[region] }}
             </div>
           {% endif %}


### PR DESCRIPTION
The `flex-grow-1` was dropped from the rework of the layouts. 
This adds that back for the two column layout which makes it so empty columns don't take up space.

Resolves #65 