### PR TITLE
Update and remove tag strips

### DIFF
--- a/layouts/edge-to-edge/layout--edge-to-edge.html.twig
+++ b/layouts/edge-to-edge/layout--edge-to-edge.html.twig
@@ -53,7 +53,7 @@
     <div class="ucb-edge-to-edge">
       <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
         {% for region in regions %}
-          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form><collection-grid><article-grid-block><article-slider-block><category-cloud-block><current-issue-block><tag-cloud-block><people-list-block><ucb-newsletter-list><latest-issue-block><article-feature-block><status-page-block><faculty-publications><article-list-block>')|trim != '' %}
+          {% if content[region] %}
             <div {{ region_attributes[region].addClass('column', 'column--' ~ region, 'col-12', 'main-column') }}>
               {{ content[region] }}
             </div>

--- a/layouts/four-column/layout--four-column.html.twig
+++ b/layouts/four-column/layout--four-column.html.twig
@@ -101,7 +101,7 @@
         {% for i in 0..(regions|length - 1) %}
           {% set region = regions[i] %}
           {% set width = column_widths[i] %}
-          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form><collection-grid><article-grid-block><article-slider-block><category-cloud-block><current-issue-block><tag-cloud-block><people-list-block><ucb-newsletter-list><latest-issue-block><article-feature-block><status-page-block><faculty-publications><article-list-block>')|trim != '' %}
+          {% if content[region] %}
             <div {{ region_attributes[region].addClass('column', 'col-lg-' ~ width, 'column--' ~ region, 'col-12', columnHeight, 'main-column') }}>
               {{ content[region] }}
             </div>

--- a/layouts/one-column/layout--one-column.html.twig
+++ b/layouts/one-column/layout--one-column.html.twig
@@ -96,7 +96,7 @@
     <div class="container ucb-contained-row">
       <div {{ attributes.addClass(row_classes, frame_classes|join(' ')) }} style="padding-left: {{ settings.section_padding_left }}; padding-right: {{ settings.section_padding_right }};">
         {% for region in ['first'] %}
-          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form><collection-grid><article-grid-block><article-slider-block><category-cloud-block><current-issue-block><tag-cloud-block><people-list-block><ucb-newsletter-list><latest-issue-block><article-feature-block><status-page-block><faculty-publications><article-list-block>')|trim != '' %}
+          {% if content[region] %}
             <div {{ region_attributes[region].addClass('column', 'column--' ~ region, 'col-12', 'main-column') }}>
               {{ content[region] }}
             </div>

--- a/layouts/three-column/layout--three-column.html.twig
+++ b/layouts/three-column/layout--three-column.html.twig
@@ -103,7 +103,7 @@
           {% set region = regions[i] %}
           {% set width = column_widths[i] %}
           {% set column_class = all_equal or width == max_width ? 'main-column' : 'auxiliary-column' %}
-          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form><collection-grid><article-grid-block><article-slider-block><category-cloud-block><current-issue-block><tag-cloud-block><people-list-block><ucb-newsletter-list><latest-issue-block><article-feature-block><status-page-block><faculty-publications><article-list-block>')|trim != '' %}
+          {% if content[region] %}
             <div {{ region_attributes[region].addClass('column', column_class, columnHeight, 'col-lg-' ~ width, 'column--' ~ region, 'col-12') }}>
               {{ content[region] }}
             </div>

--- a/layouts/three-column/layout--three-column.html.twig
+++ b/layouts/three-column/layout--three-column.html.twig
@@ -18,6 +18,7 @@
 {% set column_widths = settings.column_width|split('-') %}
 {% set row_classes = ['row', 'ucb-bootstrap-layout__row', 'ucb-bootstrap-layout__row--three-column'] %}
 {% set frameStyle = settings.content_frame_color == 'none' ? 'content-frame-unstyled' : 'content-frame-styled' %}
+{% set frameColor = 'content-frame-' ~ settings.content_frame_color %}
 {% set frame_classes = ['ucb-content-frame', frameColor, frameStyle] %}
 {% set columnHeight = settings.column_equal_height == '1' ? 'd-flex flex-wrap' : '' %}
 {% set regions = ['first', 'second', 'third'] %}

--- a/layouts/two-column/layout--two-column.html.twig
+++ b/layouts/two-column/layout--two-column.html.twig
@@ -104,7 +104,7 @@
           {% set region = regions[i] %}
           {% set width = column_widths[i] %}
           {% set column_class = all_equal or width == max_width ? 'main-column' : 'auxiliary-column' %}
-          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form><collection-grid><article-grid-block><article-slider-block><category-cloud-block><current-issue-block><tag-cloud-block><people-list-block><ucb-newsletter-list><latest-issue-block><article-feature-block><status-page-block><faculty-publications><article-list-block>')|trim != '' %}
+          {% if content[region] and content[region]|render|striptags('<img><iframe><slate-form><collection-grid><article-grid-block><article-slider-block><category-cloud-block><current-issue-block><tag-cloud-block><people-list-block><ucb-newsletter-list><latest-issue-block><article-feature-block><status-page-block><faculty-publications><article-list-block><events-calendar-block>')|trim != '' %}
             <div {{ region_attributes[region].addClass('column', column_class, columnHeight, 'col-lg-' ~ width, 'column--' ~ region, 'col-12 flex-grow-1') }}>
               {{ content[region] }}
             </div>


### PR DESCRIPTION
Updated the two column tag strip to allow the events calendar.

Removed the strip from the other layouts (one column, three column, four column, and edge-to-edge) because they do not need the check as their columns don't expand like the two column does.

Sister PR: https://github.com/CuBoulder/tiamat-theme/pull/1581