### PR TITLE
Hero Unit - undefined array key 'label' warning suppressed

### DIFF
--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -59,6 +59,7 @@ abstract class LayoutBase extends LayoutDefault
   public function defaultConfiguration(): array
   {
     return [
+      'label' => '',
       'background_color' => UCBLayout::ROW_BACKGROUND_COLOR_NONE,
       'content_frame_color' => UCBLayout::ROW_CONTENT_FRAME_COLOR_NONE,
       'background_image' == NULL,


### PR DESCRIPTION
This change eliminates a warning for the Hero Unit that would sometimes occur:
`Warning: Undefined array key "label" in Drupal\layout_builder\Form\ConfigureSectionForm->buildForm() (line 136 of /var/www/html/web/core/modules/layout_builder/src/Form/ConfigureSectionForm.php)`

This seemed to be caused by our plugin’s configuration not including a `label` key, but Layout Builder’s ConfigureSectionForm expected it.

Resolves https://github.com/CuBoulder/tiamat-theme/issues/1747